### PR TITLE
feat: Add 'Welcome to -station name-' message when no services are running

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -239,6 +239,7 @@ try:
     else:
         virtual = drawSignage(device, width=widgetWidth,
                               height=widgetHeight, data=data)
+
     timeAtStart = time.time()
     timeNow = time.time()
 
@@ -251,7 +252,8 @@ try:
             else:
                 virtual = drawSignage(device, width=widgetWidth,
                                       height=widgetHeight, data=data)
-        timeAtStart = time.time()
+
+            timeAtStart = time.time()
 
         timeNow = time.time()
         virtual.refresh()

--- a/src/main.py
+++ b/src/main.py
@@ -98,13 +98,70 @@ def renderTime(draw, width, height):
               font=fontBold, fill="yellow")
 
 
+def renderWelcomeTo(xOffset):
+    def drawText(draw, width, height):
+        text = "Welcome to"
+        draw.text((int(xOffset), 0), text=text, font=fontBold, fill="yellow")
+
+    return drawText
+
+
+def renderDepartureStation(departureStation, xOffset):
+    def draw(draw, width, height):
+        text = departureStation
+        draw.text((int(xOffset), 0), text=text, font=fontBold, fill="yellow")
+
+    return draw
+
+
+def renderDots(draw, width, height):
+    text = ".  .  ."
+    draw.text((0, 0), text=text, font=fontBold, fill="yellow")
+
+
 def loadData(apiConfig, journeyConfig):
-    departures = loadDeparturesForStation(
+    departures, stationName = loadDeparturesForStation(
         journeyConfig, apiConfig["appId"], apiConfig["apiKey"])
+
+    if len(departures) == 0:
+        return False, False, stationName
+
     firstDepartureDestinations = loadDestinationsForDeparture(
         departures[0]["service_timetable"]["id"])
 
-    return departures, firstDepartureDestinations
+    return departures, firstDepartureDestinations, stationName
+
+
+def drawBlankSignage(device, width, height, departureStation):
+    global stationRenderCount, pauseCount
+
+    with canvas(device) as draw:
+        welcomeSize = draw.textsize("Welcome to", fontBold)
+
+    with canvas(device) as draw:
+        stationSize = draw.textsize(departureStation, fontBold)
+
+    device.clear()
+
+    virtualViewport = viewport(device, width=width, height=height)
+
+    rowOne = snapshot(width, 16, renderWelcomeTo(
+        (width - welcomeSize[0]) / 2), interval=10)
+    rowTwo = snapshot(width, 16, renderDepartureStation(
+        departureStation, (width - stationSize[0]) / 2), interval=10)
+    rowThree = snapshot(width, 16, renderDots, interval=10)
+    rowTime = snapshot(width, 14, renderTime, interval=1)
+
+    if len(virtualViewport._hotspots) > 0:
+        for hotspot, xy in virtualViewport._hotspots:
+            virtualViewport.remove_hotspot(hotspot, xy)
+
+    virtualViewport.add_hotspot(rowOne, (0, 0))
+    virtualViewport.add_hotspot(rowTwo, (0, 16))
+    virtualViewport.add_hotspot(rowThree, (0, 32))
+    virtualViewport.add_hotspot(rowTime, (0, 50))
+
+    return virtualViewport
 
 
 def drawSignage(device, width, height, data):
@@ -117,7 +174,7 @@ def drawSignage(device, width, height, data):
     status = "On time"
     callingAt = "Calling at:"
 
-    departures, firstDepartureDestinations = data
+    departures, firstDepartureDestinations, departureStation = data
 
     with canvas(device) as draw:
         w, h = draw.textsize(callingAt, font)
@@ -176,17 +233,25 @@ try:
     loop_count = 0
 
     data = loadData(config["transportApi"], config["journey"])
-    virtual = drawSignage(device, width=widgetWidth,
-                          height=widgetHeight, data=data)
+    if data[0] == False:
+        virtual = drawBlankSignage(
+            device, width=widgetWidth, height=widgetHeight, departureStation=data[2])
+    else:
+        virtual = drawSignage(device, width=widgetWidth,
+                              height=widgetHeight, data=data)
     timeAtStart = time.time()
     timeNow = time.time()
 
     while True:
         if(timeNow - timeAtStart >= config["refreshTime"]):
             data = loadData(config["transportApi"], config["journey"])
-            virtual = drawSignage(device, width=widgetWidth,
-                                  height=widgetHeight, data=data)
-            timeAtStart = time.time()
+            if data[0] == False:
+                virtual = drawBlankSignage(
+                    device, width=widgetWidth, height=widgetHeight, departureStation=data[2])
+            else:
+                virtual = drawSignage(device, width=widgetWidth,
+                                      height=widgetHeight, data=data)
+        timeAtStart = time.time()
 
         timeNow = time.time()
         virtual.refresh()

--- a/src/trains.py
+++ b/src/trains.py
@@ -26,7 +26,7 @@ def loadDeparturesForStation(journeyConfig, appId, apiKey):
     if "error" in data:
         raise ValueError(data["error"])
 
-    return data["departures"]["all"]
+    return data["departures"]["all"], data["station_name"]
 
 
 def loadDestinationsForDeparture(timetableUrl):


### PR DESCRIPTION
When the API responds with no departures, the screen now shows a "Welcome to..." message. Example below:

![luma_000008](https://user-images.githubusercontent.com/1573022/59146692-43d61680-89e9-11e9-9dbd-1d718f9d7e50.png)

The refresh timer, and ticking clock, run as normal.