### PR TITLE
feat: migrate from Transport API to Realtime Trains API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 venv
 __pycache__
 config.json
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ $ sudo apt-get install libopenjp2-7
 $ pip install -r requirements.txt
 ```
 
-3. Sign up for the [Transport API](https://www.transportapi.com/), and generate an app ID and API key
+3. Sign up for the [Realtime Trains API](https://www.realtimetrains.co.uk/), and generate a username and password
 
-4. Copy `config.sample.json` to `config.json` and complete the values, including your Transport API keys from step 3. _Note: station names should be provided as their three-letter station code, all available [here](https://www.nationalrail.co.uk/stations_destinations/48541.aspx)._
+4. Copy `config.sample.json` to `config.json` and complete the values, including your Realtime Trains API keys from step 3. _Note: station names should be provided as their three-letter station code, all available [here](https://www.nationalrail.co.uk/stations_destinations/48541.aspx)._
 
 5. Start the app with:
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -5,7 +5,7 @@
   },
   "refreshTime": 120,
   "realtimeTrainsApi": {
-    "appId": "",
-    "apiKey": ""
+    "username": "",
+    "password": ""
   }
 }

--- a/config.sample.json
+++ b/config.sample.json
@@ -4,7 +4,7 @@
     "destinationStation": null
   },
   "refreshTime": 120,
-  "transportApi": {
+  "realtimeTrainsApi": {
     "appId": "",
     "apiKey": ""
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,10 @@ pycodestyle==2.5.0
 pygame==1.9.4
 pylint==2.3.1
 requests==2.22.0
-# RPi.GPIO==0.6.5
+RPi.GPIO==0.6.5
 six==1.12.0
 smbus2==0.2.2
-# spidev==3.2
+spidev==3.2
 timeloop==1.0.2
 typed-ast==1.3.5
 urllib3==1.25.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,10 @@ pycodestyle==2.5.0
 pygame==1.9.4
 pylint==2.3.1
 requests==2.22.0
-RPi.GPIO==0.6.5
+# RPi.GPIO==0.6.5
 six==1.12.0
 smbus2==0.2.2
-spidev==3.2
+# spidev==3.2
 timeloop==1.0.2
 typed-ast==1.3.5
 urllib3==1.25.3

--- a/src/main.py
+++ b/src/main.py
@@ -31,8 +31,8 @@ def makeFont(name, size):
 
 
 def renderDestination(departure):
-    departureTime = departure["aimed_departure_time"]
-    destinationName = departure["destination_name"]
+    departureTime = departure["locationDetail"]["gbttBookedDeparture"]
+    destinationName = departure["locationDetail"]["description"]
 
     def drawText(draw, width, height):
         train = f"{departureTime}  {destinationName}"
@@ -43,8 +43,8 @@ def renderDestination(departure):
 
 def renderServiceStatus(departure):
     def drawText(draw, width, height):
-        train = "On time" if departure["aimed_departure_time"] == departure[
-            "expected_departure_time"] else departure["expected_departure_time"]
+        train = "On time" if departure["locationDetail"]["gbttBookedDeparture"] == departure["locationDetail"][
+            "realtimeDeparture"] else departure["locationDetail"]["realtimeDeparture"]
 
         draw.text((0, 0), text=train, font=font, fill="yellow")
 
@@ -121,13 +121,13 @@ def renderDots(draw, width, height):
 
 def loadData(apiConfig, journeyConfig):
     departures, stationName = loadDeparturesForStation(
-        journeyConfig, apiConfig["appId"], apiConfig["apiKey"])
+        journeyConfig, apiConfig)
 
     if len(departures) == 0:
         return False, False, stationName
 
     firstDepartureDestinations = loadDestinationsForDeparture(
-        departures[0]["service_timetable"]["id"])
+        departures[0]["serviceUid"], departures[0]["runDate"], apiConfig)
 
     return departures, firstDepartureDestinations, stationName
 
@@ -236,7 +236,7 @@ try:
     pauseCount = 0
     loop_count = 0
 
-    data = loadData(config["transportApi"], config["journey"])
+    data = loadData(config["realtimeTrainsApi"], config["journey"])
     if data[0] == False:
         virtual = drawBlankSignage(
             device, width=widgetWidth, height=widgetHeight, departureStation=data[2])
@@ -249,7 +249,7 @@ try:
 
     while True:
         if(timeNow - timeAtStart >= config["refreshTime"]):
-            data = loadData(config["transportApi"], config["journey"])
+            data = loadData(config["realtimeTrainsApi"], config["journey"])
             if data[0] == False:
                 virtual = drawBlankSignage(
                     device, width=widgetWidth, height=widgetHeight, departureStation=data[2])


### PR DESCRIPTION
The long awaited resolution to #32, given Transport API's restricted usage limits, this migrates the software to use the [Realtime Trains API](https://www.realtimetrains.co.uk/).

Marked as draft right now so I can do some further testing.